### PR TITLE
Fix task executed twice on app launch

### DIFF
--- a/Forge/Classes/Forge.swift
+++ b/Forge/Classes/Forge.swift
@@ -65,12 +65,6 @@ public final class Forge {
 
   public func register(executor: Executor, for type: String) throws {
     try executionManager.register(executor: executor, for: type)
-    persistor.tasks(ofType: type) { [weak self] pTasks in
-      guard let self = self else { return }
-      for pTask in pTasks {
-        self.executionManager.execute(task: pTask)
-      }
-    }
   }
 
   public func undoTask(id: String) {


### PR DESCRIPTION
If a task was just saved to be executed and app got killed.
On app lunch -> Forge Init -> Property TaskRetrier init ->  TaskRetrier init starts safeExecuting tasks
Soon after forge init when executor is registered, it again starts executing all task. 

On registration exec of tasks is not needed as task retrier will anyhow execute them within 1 sec time loop